### PR TITLE
Remove redundancy between Enter and Update in 25_adding_values.html

### DIFF
--- a/chapter_09/25_adding_values.html
+++ b/chapter_09/25_adding_values.html
@@ -115,13 +115,7 @@
 						.attr("x", function(d, i) {				//Set new x position, based on the updated xScale
 							return xScale(i);
 						})
-						.attr("y", function(d) {				//Set new y position, based on the updated yScale
-							return h - yScale(d);
-						})
-						.attr("width", xScale.rangeBand())		//Set new width value, based on the updated xScale
-						.attr("height", function(d) {			//Set new height value, based on the updated yScale
-							return yScale(d);
-						});
+						.attr("width", xScale.rangeBand());		//Set new width value, based on the updated xScale
 
 
 


### PR DESCRIPTION
I think there is a bit of redundancy in these two code sections?  In the `bars.enter()` chain `"x"`, `"y"`, `"width"`, `"height"`, and `"fill"` are set.  In the `bars.transition()` chain, the only things that change are `"x"` and `"width"`, so I think setting `"y"` and `"height"` there again is unnecessary.
