### PR TITLE
Idea to improve chapter_10/07_sort.html

### DIFF
--- a/chapter_10/07_sort.html
+++ b/chapter_10/07_sort.html
@@ -32,6 +32,13 @@
 						.attr("width", w)
 						.attr("height", h);
 
+			var over = function() {d3.select(this).attr("fill", "orange")}
+			var out = function(d) {
+                d3.select(this)
+                    .transition()
+                    .duration(250)
+                    .attr("fill", "rgb(0, 0, " + (d * 10) + ")");
+           };
 			//Create bars
 			svg.selectAll("rect")
 			   .data(dataset)
@@ -50,16 +57,8 @@
 			   .attr("fill", function(d) {
 					return "rgb(0, 0, " + (d * 10) + ")";
 			   })
-			   .on("mouseover", function() {
-			   		d3.select(this)
-			   			.attr("fill", "orange");
-			   })
-			   .on("mouseout", function(d) {
-				   d3.select(this)
-				   		.transition()
-				   		.duration(250)
-						.attr("fill", "rgb(0, 0, " + (d * 10) + ")");
-			   })
+			   .on("mouseover", over)
+			   .on("mouseout", out)
 			   .on("click", function() {
 			   		sortBars();
 			   });
@@ -92,11 +91,23 @@
 				   	})
 				   .transition()
 				   .duration(1000)
+                   .each("start", function() {
+                        d3.select(this)
+                            .on("mouseover", null)
+                            .on("mouseout", null);
+                   })
 				   .attr("x", function(d, i) {
 				   		return xScale(i);
-				   });
-
-			};			
+				   })
+                   .attr("fill", function(d) {
+                        return "rgb(0, 0, " + (d * 10) + ")";
+                   })
+                   .each("end", function() {
+                        d3.select(this)
+                            .on("mouseover", over)
+                            .on("mouseout", out)
+                   });
+			};
 			
 		</script>
 	</body>


### PR DESCRIPTION
I know that you are not currently accepting pull requests (for a good reason), but just wanted to share an idea how to possibly improve the book in the future.
In chapter 10 example 7 (bar sorting) there is a conflict between hover animation and sorting transition animation. As a solution the book proposes to go back to CSS animation for hover, thus loosing some visual benefits of using custom JS animation. 
There is, however, a different solution: we could remove hover event listeners in transition "start" section and add them back in transition "end" section. To make this work we should also transition the bar fill color back to blue during the transition, otherwise it would be orange.
I'm not sure this concrete implementation is the optimal one, but the idea itself (suppressing event listeners during transition) is worth being illustrated in the book.
