### PR TITLE
Fixed text values not readjusting when yAxis range changes

### DIFF
--- a/chapter_09/29_dynamic_labels.html
+++ b/chapter_09/29_dynamic_labels.html
@@ -195,7 +195,8 @@
 						.duration(500)
 						.attr("x", function(d, i) {
 							return xScale(i) + xScale.rangeBand() / 2;
-						});
+						})
+                                                .attr('y', d => h - yScale(d.value) + 14);
 
 					//Exit…
 					labels.exit()


### PR DESCRIPTION
Fixed an issue where if a bar with a large value is removed, existing text values didn't readjust their Y position for the new Y axis range :)