### PR TITLE
New labels should start 1/2 a bar-width to right

### DIFF
--- a/chapter_09/29_dynamic_labels.html
+++ b/chapter_09/29_dynamic_labels.html
@@ -189,7 +189,7 @@
 							return d.value;
 						})
 						.attr("text-anchor", "middle")
-						.attr("x", w)
+						.attr("x", w + xScale.bandwidth() / 2)
 						.attr("y", function(d) {
 							return h - yScale(d.value) + 14;
 						})						


### PR DESCRIPTION
Line 192 should add half a bar width to the horizontal starting position of labels in the `enter()` selection, otherwise they are incorrectly aligned with the bar during the transition.